### PR TITLE
docs: Remove build/ directory and document lessons learned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - `docs/design/` - Complete design specifications (start here for understanding)
 - `ai_docs/` - Documentation for AI agents/subagents (PocketSmith API reference, future tax guidelines)
-- `build/` - **Temporary** reference materials from previous migration work (40+ Python scripts, 9 docs). Extract patterns/insights, then remove before publication.
 - `.env` - API configuration (**NEVER commit**, protected by .gitignore)
 
 **Navigation:**
@@ -114,24 +113,11 @@ Refer to `docs/design/2025-11-20-agent-smith-design.md` Section 11 for complete 
 7. Advanced Features (weeks 13-14)
 8. Health Check & Polish (weeks 15-16)
 
-### Working with Reference Materials
+### Reference Materials
 
-The `build/` directory contains valuable reference from previous PocketSmith migration work:
+Insights from previous PocketSmith migration work have been incorporated into Agent Smith's design.
 
-**Extract these patterns from `build/scripts/`:**
-- API client error handling and rate limiting
-- Backup/restore utilities
-- Pattern matching algorithms for transaction categorization
-- Merchant normalization logic
-- Batch processing strategies
-
-**Extract these insights from `build/docs/`:**
-- Category hierarchy optimization strategies
-- Common PocketSmith API quirks and workarounds
-- Rule creation patterns
-- Migration edge cases
-
-**See:** `build/INDEX.md` for extraction checklist
+**See:** `docs/design/LESSONS_LEARNED.md` for detailed patterns, API quirks, and best practices extracted from prior migration experience.
 
 ## Key Technical Decisions
 
@@ -219,7 +205,6 @@ Agent Smith will provide 8 slash commands in `.claude/commands/`:
 
 - **Never commit `.env`** - Contains sensitive API keys (protected by .gitignore)
 - **Always backup before mutations** - Use timestamped backup directories
-- **Build directory is temporary** - Extract value, then remove before publication
 - **Tax advice disclaimer required** - All Level 3 tax outputs must include professional advice disclaimer
 - **INDEX.md must be current** - Update whenever files are created/modified/deleted
 - Complete design specification is the source of truth: `docs/design/2025-11-20-agent-smith-design.md`

--- a/INDEX.md
+++ b/INDEX.md
@@ -17,7 +17,9 @@ This index provides a comprehensive overview of the repository structure for bot
 | `.claude/` | Directory | Claude Code configuration and commands | Active |
 | `docs/` | Directory | Documentation and design specifications | Active |
 | `ai_docs/` | Directory | Documentation for AI agents/subagents | Active |
-| `build/` | Directory | Reference materials (temporary, pre-publish) | Temporary |
+| `scripts/` | Directory | Python code organized by function | Active |
+| `data/` | Directory | Working data and configuration | Active |
+| `tests/` | Directory | Test suite (unit + integration) | Active |
 
 ---
 
@@ -58,25 +60,6 @@ Documentation specifically formatted for AI agents and subagents to reference du
 **Purpose:** Provides AI agents with comprehensive references without needing to download documentation repeatedly. Optimized for LLM consumption.
 
 **See:** [ai_docs/INDEX.md](ai_docs/INDEX.md)
-
----
-
-### `/build/` - Reference Materials (Temporary)
-
-Contains reference materials from previous PocketSmith migration work. This directory will be removed before final publication as useful content is incorporated into Agent Smith.
-
-| Path | Description | Type |
-|------|-------------|------|
-| `build/docs/` | Migration documentation (9 files) | Reference |
-| `build/scripts/` | Python scripts from migration work (40+ files) | Reference |
-
-**Purpose:** Preserve previous work for reference during Agent Smith development.
-
-**Status:** Temporary - will be removed before publish
-
-**Contents:**
-- `build/docs/` - Category hierarchy planning, migration guides, implementation notes
-- `build/scripts/` - Python scripts for categorization, analysis, migration, reporting
 
 ---
 
@@ -254,7 +237,7 @@ Contains all unit and integration tests.
 
 - **PocketSmith API Reference:** [ai_docs/pocketsmith-api-documentation.md](ai_docs/pocketsmith-api-documentation.md)
 - **Agent Smith Architecture:** [docs/design/2025-11-20-agent-smith-design.md](docs/design/2025-11-20-agent-smith-design.md)
-- **Reference Scripts:** [build/scripts/](build/scripts/)
+- **Lessons Learned:** [docs/design/LESSONS_LEARNED.md](docs/design/LESSONS_LEARNED.md)
 
 ### Key Documents
 
@@ -262,36 +245,35 @@ Contains all unit and integration tests.
 |----------|---------|----------|
 | [README.md](README.md) | Project overview | All |
 | [docs/design/2025-11-20-agent-smith-design.md](docs/design/2025-11-20-agent-smith-design.md) | Complete design spec | Developers, AI agents |
+| [docs/design/LESSONS_LEARNED.md](docs/design/LESSONS_LEARNED.md) | Migration insights | Developers, AI agents |
 | [ai_docs/pocketsmith-api-documentation.md](ai_docs/pocketsmith-api-documentation.md) | API reference | AI agents |
 
 ---
 
 ## File Counts
 
-- **Documentation Files:** 2 (+ 9 in build/docs)
-- **Design Specifications:** 1
-- **AI Reference Docs:** 1
-- **Reference Scripts:** 40+ (in build/scripts)
+- **Documentation Files:** 3 (design spec + lessons learned + README)
+- **AI Reference Docs:** 1 (PocketSmith API)
+- **Python Scripts:** 60+ files across scripts/ directory
+- **Test Files:** 35+ test files (350 tests total)
 
 ---
 
 ## Repository Size
 
-- **Active Files:** ~812KB
-- **Build Reference:** ~1MB
-- **Total:** ~2MB
-- **Backup (original work):** 341MB at `../budget-smith-backup-20251120_093733/`
+- **Active Files:** ~1.8MB (production-ready)
+- **Backup (original migration work):** 341MB at `../budget-smith-backup-20251120_093733/`
 
 ---
 
 ## Notes
 
 - `.env` file contains sensitive API keys and is protected by `.gitignore`
-- `build/` directory is temporary and will be removed before publication
-- All useful content from `build/` will be incorporated into Agent Smith skill structure
-- Complete backup of original work exists at `../budget-smith-backup-20251120_093733/`
+- All insights from previous migration work documented in `docs/design/LESSONS_LEARNED.md`
+- Complete backup of original migration work exists at `../budget-smith-backup-20251120_093733/`
+- Repository is publication-ready (all temporary reference materials removed)
 
 ---
 
-**Last Updated:** 2025-11-21
-**Repository Version:** Phase 8 Complete (100% Implementation)
+**Last Updated:** 2025-11-23
+**Repository Version:** 1.2.0 - Publication Ready

--- a/README.md
+++ b/README.md
@@ -733,4 +733,4 @@ For questions or issues, please refer to the design documentation or create an i
 
 ---
 
-**Note:** This project is in active development. The `build/` directory contains reference materials from previous migration work and will be removed before final publication.
+**Note:** For insights from previous PocketSmith migration work that informed this project, see [Lessons Learned](docs/design/LESSONS_LEARNED.md).

--- a/docs/design/LESSONS_LEARNED.md
+++ b/docs/design/LESSONS_LEARNED.md
@@ -1,0 +1,327 @@
+# Lessons Learned from PocketSmith Migration
+
+**Date:** 2025-11-23
+**Source:** build/ directory reference materials (now archived)
+
+This document captures key insights from a previous PocketSmith category migration project that informed Agent Smith's design.
+
+---
+
+## Table of Contents
+
+1. [API Quirks and Workarounds](#api-quirks-and-workarounds)
+2. [Category Hierarchy Best Practices](#category-hierarchy-best-practices)
+3. [Transaction Categorization Patterns](#transaction-categorization-patterns)
+4. [Merchant Name Normalization](#merchant-name-normalization)
+5. [User Experience Lessons](#user-experience-lessons)
+
+---
+
+## API Quirks and Workarounds
+
+### Category Rules API Limitations
+
+**Issue:** PocketSmith API does not support updating or deleting category rules.
+- GET `/categories/{id}/category_rules` works
+- POST works (create only)
+- PUT/PATCH/DELETE return 404 errors
+
+**Impact:** Rules created via API cannot be modified programmatically.
+
+**Agent Smith Solution:** Hybrid rule engine with local rules for complex logic, platform rules for simple keywords only.
+
+### Transaction Migration 500 Errors
+
+**Issue:** Bulk transaction updates sometimes fail with 500 Internal Server Errors.
+
+**Root Cause:** Likely API rate limiting or server-side stability issues.
+
+**Agent Smith Solution:**
+- Implement rate limiting (0.1-0.5s delay between requests)
+- Batch processing with progress tracking
+- Retry logic with exponential backoff
+- Always backup before bulk operations
+
+### Special Characters in Category Names
+
+**Issue:** Using "&" in category names causes 422 Unprocessable Entity errors.
+
+**Workaround:** Replace "&" with "and" in all category names.
+
+**Example:**
+- ❌ "Takeaway & Food Delivery" → 422 error
+- ✅ "Takeaway and Food Delivery" → Success
+
+### Use PUT instead of PATCH
+
+**Issue:** PATCH for transaction updates is unreliable in PocketSmith API.
+
+**Solution:** Always use PUT for transaction updates.
+
+```python
+# ✅ Correct
+response = requests.put(
+    f'https://api.pocketsmith.com/v2/transactions/{txn_id}',
+    headers=headers,
+    json={'category_id': category_id}
+)
+
+# ❌ Avoid (unreliable)
+response = requests.patch(...)
+```
+
+---
+
+## Category Hierarchy Best Practices
+
+### Parent-Child Structure
+
+**Recommendation:** Use 2-level hierarchy maximum.
+- 12-15 parent categories for broad grouping
+- 2-5 children per parent for specific tracking
+- Avoid 3+ levels (PocketSmith UI gets cluttered)
+
+**Example Structure:**
+```
+Food & Dining (parent)
+├── Groceries
+├── Restaurants
+├── Takeaway and Food Delivery
+└── Coffee Shops
+```
+
+### Duplicate Category Detection
+
+**Problem:** Duplicate categories accumulate over time, causing confusion.
+
+**Solution:** Before creating categories, check for existing matches:
+1. Flatten nested category structure
+2. Check both exact matches and case-insensitive matches
+3. Check for variations (e.g., "Takeaway" vs "Takeaways")
+
+**Agent Smith Implementation:** Category validation in health check system.
+
+### Consolidation Strategy
+
+**Insight:** Merging duplicate categories is risky:
+- Requires migrating all associated transactions
+- Transaction updates can fail (500 errors)
+- Better to prevent duplicates than merge later
+
+**Agent Smith Approach:** Template-based setup with validation prevents duplicates upfront.
+
+---
+
+## Transaction Categorization Patterns
+
+### Pattern Matching Complexity
+
+**Observation:** Transaction categorization evolved through multiple rounds:
+- Round 1: Simple keyword matching (60% coverage)
+- Round 2: Pattern matching with normalization (80% coverage)
+- Round 3: User clarifications + edge cases (90% coverage)
+- Round 4: Manual review of exceptions (95% coverage)
+
+**Lesson:** Need both automated rules AND user override capability.
+
+**Agent Smith Solution:** Tiered intelligence modes (Conservative/Smart/Aggressive) with confidence scoring.
+
+### Confidence-Based Auto-Apply
+
+**Insight:** Not all matches are equal:
+- High confidence (95%+): Auto-apply safe (e.g., "WOOLWORTHS" → Groceries)
+- Medium confidence (70-94%): Ask user (e.g., "LS DOLLI PL" → Coffee?)
+- Low confidence (<70%): Always ask (e.g., "Purchase At Kac" → ???)
+
+**Agent Smith Implementation:**
+```python
+if confidence >= 90:  # Smart mode threshold
+    apply_automatically()
+elif confidence >= 70:
+    ask_user_for_approval()
+else:
+    skip_or_manual_review()
+```
+
+### Dry-Run Mode is Critical
+
+**Lesson:** Always preview before bulk operations.
+
+**Pattern from migration:**
+```python
+class BulkCategorizer:
+    def __init__(self, dry_run=True):  # Default to dry-run!
+        self.dry_run = dry_run
+
+    def categorize_transactions(self):
+        if self.dry_run:
+            # Show what WOULD happen
+            return preview
+        else:
+            # Actually execute
+            return results
+```
+
+**Agent Smith Implementation:** All bulk operations support `--mode=dry_run` flag.
+
+---
+
+## Merchant Name Normalization
+
+### Common Payee Patterns
+
+**Observations from transaction data:**
+
+1. **Location codes:** "WOOLWORTHS 1234" → "WOOLWORTHS"
+2. **Legal suffixes:** "COLES PTY LTD" → "COLES"
+3. **Country codes:** "UBER AU" → "UBER"
+4. **Transaction codes:** "PURCHASE NSWxxx123" → "PURCHASE"
+5. **Direct debit patterns:** "DIRECT DEBIT 12345" → "DIRECT DEBIT"
+
+**Agent Smith Patterns:**
+```python
+LOCATION_CODE_PATTERN = r"\s+\d{4,}$"
+SUFFIX_PATTERNS = [
+    r"\s+PTY\s+LTD$",
+    r"\s+LIMITED$",
+    r"\s+LTD$",
+    r"\s+AU$",
+]
+```
+
+### Merchant Variation Grouping
+
+**Problem:** Same merchant appears with multiple names:
+- "woolworths"
+- "WOOLWORTHS PTY LTD"
+- "Woolworths 1234"
+- "WOOLWORTHS SUPERMARKETS"
+
+**Solution:** Learn canonical names from transaction history.
+
+**Agent Smith Implementation:** `MerchantNormalizer.learn_from_transactions()` in scripts/utils/merchant_normalizer.py:101-130
+
+---
+
+## User Experience Lessons
+
+### Backups are Non-Negotiable
+
+**Critical Lesson:** ALWAYS backup before mutations.
+
+**Migration practice:**
+```python
+def categorize_transactions(self):
+    # Step 1: Always backup first
+    self.backup_transactions()
+
+    # Step 2: Then execute
+    self.apply_changes()
+```
+
+**Agent Smith Policy:** Automatic backups before all mutation operations, tracked in backups/ directory.
+
+### Progress Visibility Matters
+
+**Problem:** Long-running operations feel broken without progress indicators.
+
+**Solution:** Show progress every N iterations:
+```python
+for i, txn in enumerate(transactions, 1):
+    # Process transaction
+
+    if i % 100 == 0:
+        print(f"Progress: {i}/{total} ({i/total*100:.1f}%)")
+```
+
+**Agent Smith Implementation:** All batch operations show real-time progress.
+
+### Manual Cleanup is Inevitable
+
+**Reality Check:** Even after 5+ rounds of automated categorization, ~5% of transactions needed manual review.
+
+**Reasons:**
+- Genuinely ambiguous merchants ("Purchase At Kac" = gambling)
+- One-off transactions (unique payees)
+- Data quality issues (missing/incorrect payee names)
+
+**Agent Smith Approach:** Make manual review easy with health check reports showing uncategorized transactions.
+
+### Weekly Review Habit
+
+**Post-migration recommendation:** Review recent transactions weekly for first month.
+
+**Why:** Helps catch:
+- Miscategorized transactions
+- New merchants needing rules
+- Changes in spending patterns
+
+**Agent Smith Feature:** Smart alerts with weekly budget reviews (Phase 7).
+
+---
+
+## Implementation Timelines
+
+### Migration Timeline (Reality vs Plan)
+
+**Planned:** 35 minutes total
+**Actual:** 3+ hours over multiple days
+
+**Breakdown:**
+- Category structure migration: 10 minutes (as planned)
+- Rule recreation: 20 minutes (10 minutes planned - API limitations doubled time)
+- Transaction categorization Round 1: 30 minutes
+- Transaction categorization Round 2: 45 minutes
+- Transaction categorization Round 3: 60 minutes
+- Manual cleanup and verification: 90 minutes
+
+**Lesson:** Budget 3-5x estimated time for data migration projects.
+
+**Agent Smith Design:** Incremental onboarding (30-60 minutes initial setup, ongoing refinement).
+
+---
+
+## Key Takeaways for Agent Smith
+
+### What We Built Better
+
+1. **Hybrid Rule Engine:** Local + Platform rules overcome API limitations
+2. **Confidence Scoring:** Tiered auto-apply based on pattern strength
+3. **Merchant Intelligence:** Learned normalization from transaction history
+4. **Health Checks:** Proactive detection of category/rule issues
+5. **Template System:** Pre-built rule sets prevent common mistakes
+
+### What We Avoided
+
+1. **Manual rule migration** - Templates and import/export instead
+2. **Duplicate categories** - Validation and health checks
+3. **Bulk update failures** - Rate limiting, retry logic, batching
+4. **Lost context** - Comprehensive backups with metadata
+5. **User fatigue** - Incremental categorization, not all-at-once
+
+### Core Principles
+
+✅ **Backup before mutations**
+✅ **Dry-run before execute**
+✅ **Progress visibility**
+✅ **Confidence-based automation**
+✅ **User choice over forced automation**
+✅ **Learn from transaction history**
+✅ **Graceful degradation** (LLM fallback when rules don't match)
+
+---
+
+## Reference
+
+**Original Materials:** Archived from `build/` directory (removed 2025-11-23)
+
+**Full backup available at:** `../budget-smith-backup-20251120_093733/`
+
+**See Also:**
+- [Agent Smith Design](2025-11-20-agent-smith-design.md) - Complete system design
+- [Unified Rules Guide](../guides/unified-rules-guide.md) - Rule engine documentation
+- [Health Check Guide](../guides/health-check-guide.md) - Health scoring system
+
+---
+
+**Last Updated:** 2025-11-23


### PR DESCRIPTION
## Summary

Removed the temporary `build/` directory and documented all valuable insights in a new `LESSONS_LEARNED.md` file, making the repository publication-ready.

## Changes

### Added
- **`docs/design/LESSONS_LEARNED.md`** - Comprehensive documentation of migration insights
  - API quirks and workarounds (category rules limitations, 500 errors, special characters)
  - Category hierarchy best practices (2-level max, duplicate detection)
  - Transaction categorization patterns (confidence scoring, dry-run mode)
  - Merchant name normalization strategies (location codes, legal suffixes)
  - User experience lessons (backups, progress visibility, manual cleanup)

### Removed
- **`build/` directory** - All temporary reference materials
  - 40+ Python scripts from previous migration work
  - 9 migration documentation files
  - All patterns already incorporated into Agent Smith implementation
  - Full backup preserved at `../budget-smith-backup-20251120_093733/`

### Updated
- **`README.md`** - Replaced build/ reference with lessons learned link
- **`CLAUDE.md`** - Removed build/ references from repository structure and guidance
- **`INDEX.md`** - Removed build/ section, marked repository as publication-ready (v1.2.0)

## Impact

✅ **Repository is now publication-ready**
- All temporary reference materials removed
- All insights properly documented
- Clean repository structure
- No breaking changes to existing functionality

## Verification

```bash
# Verify build/ directory removed
ls -la /home/slamb2k/work/agent-smith/ | grep build
# (no output = successfully removed)

# Verify lessons learned documentation
cat docs/design/LESSONS_LEARNED.md
# (comprehensive migration insights documented)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)