### PR TITLE
feat: Add CLI interfaces to template scripts and bump version to 1.3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Agent Smith provides comprehensive PocketSmith API integration with advanced AI-
 
 ✅ **Implementation Complete** - All 8 phases implemented and tested
 
-📦 **Version:** 1.3.7
+📦 **Version:** 1.3.8
 
 📋 **Design Document:** [docs/design/2025-11-20-agent-smith-design.md](docs/design/2025-11-20-agent-smith-design.md)
 

--- a/agent-smith-plugin/.claude-plugin/plugin.json
+++ b/agent-smith-plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-smith-plugin",
   "description": "Intelligent financial management plugin containing an intelligent skill for Claude Code with PocketSmith API integration. Features AI-powered categorization, tax intelligence, scenario planning, and health checks.",
-  "version": "1.1.3",
+  "version": "1.3.8",
   "author": {
     "name": "slamb2k",
     "email": "slamb2k@users.noreply.github.com"

--- a/agent-smith-plugin/skills/agent-smith/README.md
+++ b/agent-smith-plugin/skills/agent-smith/README.md
@@ -153,7 +153,7 @@ uv run python -u scripts/operations/batch_categorize.py --mode=dry_run
 
 ## Version History
 
-- **1.3.7** - Complete implementation (all 8 phases)
+- **1.3.8** - Complete implementation (all 8 phases)
 - **1.0.0** - Initial skill package
 
 ## Notes

--- a/agent-smith-plugin/skills/agent-smith/SKILL.md
+++ b/agent-smith-plugin/skills/agent-smith/SKILL.md
@@ -465,7 +465,7 @@ For detailed documentation, see the `references/` directory:
 
 ## Support
 
-**Version**: 1.3.7
+**Version**: 1.3.8
 
 **Documentation**: See references/ directory for comprehensive guides
 

--- a/agent-smith-plugin/skills/agent-smith/pyproject.toml
+++ b/agent-smith-plugin/skills/agent-smith/pyproject.toml
@@ -56,7 +56,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-smith"
-version = "1.3.7"
+version = "1.3.8"
 description = "Intelligent financial management skill for Claude Code with PocketSmith API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-smith"
-version = "1.3.7"
+version = "1.3.8"
 description = "Intelligent financial management skill for Claude Code with PocketSmith API integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/setup/template_merger.py
+++ b/scripts/setup/template_merger.py
@@ -1,5 +1,11 @@
 """Template merging logic for composable template system."""
 
+import argparse
+import json
+import os
+import sys
+import yaml
+from pathlib import Path
 from typing import Dict, Any, List, Set
 from datetime import datetime
 
@@ -80,3 +86,124 @@ class TemplateMerger:
             )
 
         return merged
+
+
+def load_template(template_path: Path) -> Dict[str, Any]:
+    """Load a YAML template file."""
+    with open(template_path, "r") as f:
+        data = yaml.safe_load(f)
+        if not isinstance(data, dict):
+            raise ValueError(f"Template file {template_path} must contain a YAML dictionary")
+        return data
+
+
+def get_plugin_assets_dir() -> Path:
+    """Get the plugin assets directory, supporting both dev and installed modes."""
+    # Check if running from plugin
+    plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if plugin_root:
+        return Path(plugin_root) / "assets"
+
+    # Development mode - check if we're in the plugin structure
+    script_dir = Path(__file__).parent
+
+    # If scripts/setup/template_merger.py, go up to find assets
+    if (script_dir.parent.parent / "assets" / "templates").exists():
+        return script_dir.parent.parent / "assets"
+
+    # Otherwise use agent-smith-plugin structure
+    return script_dir.parent.parent / "agent-smith-plugin" / "skills" / "agent-smith" / "assets"
+
+
+def main() -> None:
+    """CLI interface for template merging."""
+    parser = argparse.ArgumentParser(
+        description="Merge Agent Smith templates into a single configuration"
+    )
+    parser.add_argument(
+        "--primary",
+        required=True,
+        help="Primary income template (e.g., payg-employee, sole-trader)",
+    )
+    parser.add_argument(
+        "--living",
+        help="Living arrangement templates, comma-separated (e.g., shared-hybrid)",
+    )
+    parser.add_argument(
+        "--additional",
+        help="Additional income templates, comma-separated (e.g., property-investor)",
+    )
+    parser.add_argument(
+        "--config", type=Path, help="Path to template_config.json with label customizations"
+    )
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Output path for merged template JSON"
+    )
+
+    args = parser.parse_args()
+
+    # Get templates directory
+    templates_dir = get_plugin_assets_dir() / "templates"
+
+    if not templates_dir.exists():
+        print(f"Error: Templates directory not found: {templates_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load templates
+    templates = []
+
+    # Load primary template
+    primary_file = templates_dir / "primary" / f"{args.primary}.yaml"
+    if not primary_file.exists():
+        print(f"Error: Primary template not found: {primary_file}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading primary: {args.primary}")
+    templates.append(load_template(primary_file))
+
+    # Load living templates
+    if args.living:
+        for living in args.living.split(","):
+            living = living.strip()
+            living_file = templates_dir / "living" / f"{living}.yaml"
+            if not living_file.exists():
+                print(f"Error: Living template not found: {living_file}", file=sys.stderr)
+                sys.exit(1)
+            print(f"Loading living: {living}")
+            templates.append(load_template(living_file))
+
+    # Load additional templates
+    if args.additional:
+        for additional in args.additional.split(","):
+            additional = additional.strip()
+            additional_file = templates_dir / "additional" / f"{additional}.yaml"
+            if not additional_file.exists():
+                print(f"Error: Additional template not found: {additional_file}", file=sys.stderr)
+                sys.exit(1)
+            print(f"Loading additional: {additional}")
+            templates.append(load_template(additional_file))
+
+    # Merge templates
+    print("\nMerging templates...")
+    merger = TemplateMerger()
+    merged = merger.merge(templates)
+
+    # Save merged template
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output, "w") as f:
+        json.dump(merged, f, indent=2)
+
+    print(f"\n✓ Merged template saved to: {args.output}")
+    print("\nTemplates merged:")
+    for t in merged["metadata"]["templates_applied"]:
+        print(f"  • {t['name']} ({t['layer']}, priority {t['priority']})")
+
+    print("\nSummary:")
+    print(f"  • {len(merged['categories'])} categories")
+    print(f"  • {len(merged['rules'])} rules")
+    print(f"  • {len(merged['labels'])} labels")
+    print(f"  • {len(merged['alerts'])} alerts")
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agent-smith"
-version = "1.3.6"
+version = "1.3.8"
 source = { editable = "." }
 dependencies = [
     { name = "claude-agent-sdk" },


### PR DESCRIPTION
## Summary

- Added complete argparse-based CLI interfaces to template_merger.py and template_applier.py
- Scripts were previously unusable from command line (only had class definitions)
- Unified plugin and project versions to 1.3.8 (plugin was at 1.1.3, project at 1.3.7)

## Changes

### Template Scripts
- ✅ Added full CLI interface with argparse to `template_merger.py`
- ✅ Added full CLI interface with argparse to `template_applier.py`
- ✅ Added `load_template()` helper with YAML type checking
- ✅ Added `get_plugin_assets_dir()` for plugin/dev mode support
- ✅ Applied changes to both `scripts/` and `agent-smith-plugin/skills/agent-smith/scripts/` locations
- ✅ Fixed all linting violations (E501 line length, F541 f-string placeholders)

### Version Unification (1.3.8)
- ✅ `agent-smith-plugin/.claude-plugin/plugin.json` (1.1.3 → 1.3.8)
- ✅ `pyproject.toml` (1.3.7 → 1.3.8)
- ✅ `README.md` (1.3.7 → 1.3.8)
- ✅ `agent-smith-plugin/skills/agent-smith/pyproject.toml` (1.3.7 → 1.3.8)
- ✅ `agent-smith-plugin/skills/agent-smith/README.md` (1.3.7 → 1.3.8)
- ✅ `agent-smith-plugin/skills/agent-smith/SKILL.md` (1.3.7 → 1.3.8)

## Test Plan

- ✅ All pre-commit hooks passed (lint, format, type-check)
- ✅ Tested both scripts with CLI arguments successfully
- ✅ Type checking passes (68 source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)